### PR TITLE
Fixed markdown editor file paths

### DIFF
--- a/src/views/partials/markdownEditor.hbs
+++ b/src/views/partials/markdownEditor.hbs
@@ -27,7 +27,7 @@
     <div id="editorOut" class="mdOut"></div>
   </div>
 </div>
-<script src="/static/third-party/commonmark.min.js"></script>
-<script src="/static/third-party/prism.js"></script>
+<script src="/static/js/third-party/commonmark.min.js"></script>
+<script src="/static/js/third-party/prism.js"></script>
 <script src="/static/js/mdEditor.js"></script>
 <link rel="stylesheet" href="/static/css/mdEditor.css"/>


### PR DESCRIPTION
## Expected behavior
The editor loads in nicely.

## Actual behavior
The editor doesn't load correctly. It can't access two files in folder /static/third-party as that folder doesn't exist.

## Description of fix
Corrected the two files paths to point to correct location.

Reference(s): #11 