### PR TITLE
Markdown editor leave confirmation is disabled if the form is submitted

### DIFF
--- a/src/static/js/mdEditor.js
+++ b/src/static/js/mdEditor.js
@@ -65,8 +65,19 @@ onEdit();
 // user to make changes to trigger the confirmation.
 changesMade = false;
 
+function processSubmit () {
+  changesMade = false;
+}
+
 window.onbeforeunload = function () {
   if (changesMade) {
     return 'Are you sure you want to leave?';
+  }
+};
+
+window.onload = function () {
+  var elements = document.getElementsByTagName('form');
+  for (var i = 0; i < elements.length; i++) {
+    elements[i].addEventListener('submit', processSubmit);
   }
 };


### PR DESCRIPTION
## Expected behavior
There shouldn't be confirmation to leave the page if the form is submitted.
## Actual behavior
There is page leave confirmation when the form is submitted.
## Description of fix
The markdown editor adds event listener to all of the forms on the page where the markdown editor exists. The listener sets the changesMade flag to false and that way disables the page leave confirmation.

Reference(s): #24 