### PR TITLE
Added link to the bottom of the index page to go to the archive page

### DIFF
--- a/src/views/index.hbs
+++ b/src/views/index.hbs
@@ -34,6 +34,11 @@
           {{>projectBrief}}
         </li>
       {{/each}}
+      <li>
+        <div class="container projectContainer indexProjectClickArea">
+          <a href="/archive">View more articles.</a>
+        </div>
+      </li>
     </ul>
   </div>
 {{/layout}}


### PR DESCRIPTION
## Description of feature
Having a link to the archive at the bottom of the index page allows to direct the user to read more.
## Description of implementation
Added link to the bottom using existing css classes.

Reference(s): #25 