### PR TITLE
Added ability to set the publication date and time.

### DIFF
--- a/src/db/models/project.js
+++ b/src/db/models/project.js
@@ -27,8 +27,8 @@ const projectSchema = new mongoose.Schema({
   body: {type: String, required: true},
   rawBody: {type: String, required: true},
   brief: {type: String, required: true},
-  postedAt: {type: Date, default: Date.now, required: true},
-  updatedAt: {type: Date, default: Date.now},
+  postedAt: {type: Date, default: null},
+  updatedAt: {type: Date, default: null},
   indexImageUrl: {type: String, default: 'https://i.imgur.com/5Dmkrgz.png'},
   author: {
     id: {type: String, required: true},

--- a/src/srv/hbsSystem.js
+++ b/src/srv/hbsSystem.js
@@ -100,6 +100,14 @@ hbs.registerHelper('timeFromNow', function (time) {
   return moment(time).fromNow();
 });
 
+hbs.registerHelper('getDateString', function (mongooseDate) {
+  return moment(mongooseDate).format('YYYY-MM-DD');
+});
+
+hbs.registerHelper('getTimeString', function (mongooseDate) {
+  return moment(mongooseDate).format('hh:mm');
+});
+
 hbs.registerPartial(partials);
 
 recompileAll();

--- a/src/srv/routes/project.js
+++ b/src/srv/routes/project.js
@@ -27,6 +27,7 @@ const auth0Api = require('../../lib/auth0Api');
 const processMarkdown = require('../processMarkdown');
 const querys = require('../../db/querys');
 const validator = require('validator');
+const moment = require('moment');
 
 router.param('project', function (req, res, next, project) {
   if (!validator.matches(project, /^[a-zA-Z0-9_-]+$/g)) {
@@ -158,8 +159,16 @@ router.post('/edit', ensureAdmin, function (req, res, next) {
   if (req.body.public) {
     update.public = req.body.public;
   }
+  if (req.body.editUpdatedAt && update.public > 0 && req.body.postedAtHours && req.body.postedAtDate && req.body.timeZone) {
+    let postedAt = moment.utc(req.body.postedAtDate + 'T' + req.body.postedAtHours + 'Z');
+    postedAt.utcOffset(-1 * Number(req.body.timeZone), true);
+    update.postedAt = postedAt.toISOString();
+    // Set the editedAt time to equal the postedAt time so that the edited on time is
+    // not shown on the project page
+    update.updatedAt = postedAt.toISOString();
+  }
 
-  models.project.findByIdAndUpdate(req.body.projectId, update, (err, data) => {
+  models.project.findByIdAndUpdate(req.body.projectId, {$set: update}, (err, data) => {
     if (err) {
       return next(err);
     }
@@ -207,6 +216,13 @@ router.post('/new', ensureAdmin, function (req, res, next) {
     brief: req.body.brief,
     public: p
   });
+
+  if (newProject.public !== 0) {
+    newProject.postedAt = Date.now();
+    // Set the editedAt time to equal the postedAt time so that the edited on time is
+    // not shown on the project page
+    newProject.updatedAt = newProject.postedAt;
+  }
 
   newProject.save((err, data) => {
     if (err) {

--- a/src/srv/routes/project.js
+++ b/src/srv/routes/project.js
@@ -159,7 +159,12 @@ router.post('/edit', ensureAdmin, function (req, res, next) {
   if (req.body.public) {
     update.public = req.body.public;
   }
-  if (req.body.editUpdatedAt && update.public > 0 && req.body.postedAtHours && req.body.postedAtDate && req.body.timeZone) {
+  if (req.body.editUpdatedAt && req.body.setPublicationTimeToNow) {
+    update.postedAt = Date.now();
+    update.updatedAt = update.postedAt;
+  }
+  if (req.body.editUpdatedAt && update.public > 0 && !req.body.setPublicationTimeToNow &&
+    req.body.postedAtHours && req.body.postedAtDate && req.body.timeZone) {
     let postedAt = moment.utc(req.body.postedAtDate + 'T' + req.body.postedAtHours + 'Z');
     postedAt.utcOffset(-1 * Number(req.body.timeZone), true);
     update.postedAt = postedAt.toISOString();

--- a/src/static/js/mdEditor.js
+++ b/src/static/js/mdEditor.js
@@ -69,6 +69,15 @@ function processSubmit () {
   changesMade = false;
 }
 
+function updatedTimeControl (e) {
+  if (e.target) {
+    e = e.target;
+  }
+  document.getElementById('postedAt').disabled = !e.checked;
+  document.getElementById('postedAtHours').disabled = !e.checked;
+  document.getElementById('timeZone').disabled = !e.checked;
+}
+
 window.onbeforeunload = function () {
   if (changesMade) {
     return 'Are you sure you want to leave?';
@@ -80,4 +89,19 @@ window.onload = function () {
   for (var i = 0; i < elements.length; i++) {
     elements[i].addEventListener('submit', processSubmit);
   }
+
+  document.getElementById('editUpdatedAt').addEventListener('click', updatedTimeControl);
+  updatedTimeControl(document.getElementById('editUpdatedAt'));
+
+  var offset = new Date().getTimezoneOffset();
+  var postedAtHours = document.getElementById('postedAtHours');
+  if (!postedAtHours) {
+    return;
+  }
+  var time = new Date('1970-01-01T' + postedAtHours.value + 'Z');
+  time = new Date(time.getTime() + offset * 60000);
+  postedAtHours.value = (time.getHours().toString().length === 1
+    ? '0' + time.getHours()
+    : time.getHours()) + ':' + time.getMinutes();
+  document.getElementById('timeZone').value = offset;
 };

--- a/src/static/js/mdEditor.js
+++ b/src/static/js/mdEditor.js
@@ -76,6 +76,7 @@ function updatedTimeControl (e) {
   document.getElementById('postedAt').disabled = !e.checked;
   document.getElementById('postedAtHours').disabled = !e.checked;
   document.getElementById('timeZone').disabled = !e.checked;
+  document.getElementById('setPublicationTime').disabled = !e.checked;
 }
 
 window.onbeforeunload = function () {

--- a/src/views/project/editProject.hbs
+++ b/src/views/project/editProject.hbs
@@ -48,6 +48,17 @@
         <option value="1" {{#if_eq project.public 1}}selected="selected"{{/if_eq}}>Public</option>
         <option value="2" {{#if_eq project.public 2}}selected="selected"{{/if_eq}}>Link only</option>
       </select><br>
+      {{#if isEdit}}
+        <label for="editUpdatedAt">Edit publishing time:</label>
+        <input type="checkbox" id="editUpdatedAt" name="editUpdatedAt"><br>
+        <span>Published on: </span>
+        <label for="postedAt">Date:</label>
+        <input id="postedAt" name="postedAtDate" type="date" value="{{getDateString project.postedAt}}">
+        <label for="postedAtHours">Time:</label>
+        <input id="postedAtHours" name="postedAtHours" type="time" value="{{getTimeString project.postedAt}}">
+        <label for="timeZone">Timezone:</label>
+        <input id="timeZone" name="timeZone" type="text" readonly value="UTC"><br>
+      {{/if}}
       <input type="submit">
     </div>
   </form>

--- a/src/views/project/editProject.hbs
+++ b/src/views/project/editProject.hbs
@@ -51,6 +51,8 @@
       {{#if isEdit}}
         <label for="editUpdatedAt">Edit publishing time:</label>
         <input type="checkbox" id="editUpdatedAt" name="editUpdatedAt"><br>
+        <label for="setPublicationTime">Set publication time to now:</label>
+        <input type="checkbox" id="setPublicationTime" name="setPublicationTimeToNow"><br>
         <span>Published on: </span>
         <label for="postedAt">Date:</label>
         <input id="postedAt" name="postedAtDate" type="date" value="{{getDateString project.postedAt}}">


### PR DESCRIPTION
## Description of feature
When editing a article there is options to edit the publication date. The project needs to be public to edit the publication time.
## Description of implementation
The article edit page has new controls to edit the publication date and time. The controls need to be enabled using a checkbox in order to do any edits to the date and time.
## Remarks
Article publication date and time aren't set automatically when the project is first set to public if the publication is done using the edit page. The publication date and time is set automatically if the article is set public when it is first posted

Reference(s): #8 