### PR TITLE
Fix #48 and remove partial that is part of upcoming image hosting system but is not yet used.

### DIFF
--- a/src/srv/hbsSystem.js
+++ b/src/srv/hbsSystem.js
@@ -63,8 +63,7 @@ const partials = {
   adminLayout: getPartialHbs('adminLayout.hbs'),
   adminNav: getPartialHbs('adminNav.hbs'),
   adminNavItem: getPartialHbs('adminNavItem.hbs'),
-  adminArticle: getPartialHbs('adminArticle.hbs'),
-  imageUpload: getPartialHbs('imageUpload.hbs')
+  adminArticle: getPartialHbs('adminArticle.hbs')
 };
 
 function reloadPartials () {

--- a/src/views/archive.hbs
+++ b/src/views/archive.hbs
@@ -21,7 +21,9 @@
 }}
 {{#> header}}
   {{#each articles}}
-    <link rel="preload" as="image" href="{{indexImageUrl}}"/>
+    {{#if indexImageUrl}}
+      <link rel="preload" as="image" href="{{indexImageUrl}}"/>
+    {{/if}}
   {{/each}}
 {{/header}}
 {{#>layout}}


### PR DESCRIPTION
## Expected behavior

If there is no url to the image it shouldn't be preloaded.

## Actual behavior

Images without valid url are put to the preload list.

## Description of fix

Conditionalized the adding of preload request. It is not added if there is no url.

Reference(s): #48