### PR TITLE
Archive page now shows link only articles to admins.

### DIFF
--- a/src/scss/_containers.scss
+++ b/src/scss/_containers.scss
@@ -138,3 +138,7 @@
 .radio {
   padding-left: 5px;
 }
+
+.link-only {
+  background-color: $secondary-color;
+}

--- a/src/srv/routes/archive.js
+++ b/src/srv/routes/archive.js
@@ -107,7 +107,7 @@ function getArchive (req, res, next) {
     })
     .then(() => {
       let q = {public: 1};
-      if (req.user.app_metadata.admin === true) {
+      if ( req.user && req.user.app_metadata && req.user.app_metadata.admin === true) {
         q = {$or: [{public: 1}, {public: 2}]};
       }
       return models.article.find(q)

--- a/src/srv/routes/archive.js
+++ b/src/srv/routes/archive.js
@@ -106,12 +106,16 @@ function getArchive (req, res, next) {
       req.context.pagination = req.context.pagination.concat(temp);
     })
     .then(() => {
-      return models.article.find({public: 1})
+      let q = {public: 1};
+      if (req.user.app_metadata.admin === true) {
+        q = {$or: [{public: 1}, {public: 2}]};
+      }
+      return models.article.find(q)
         .skip(req.params.page * req.params.count)
         .limit(req.params.count)
         .sort('-postedAt')
         .lean()
-        .select('postedAt updatedAt author brief title indexImageUrl')
+        .select('postedAt updatedAt author brief title indexImageUrl public')
         .exec();
     })
     .then(data => {

--- a/src/srv/routes/base.js
+++ b/src/srv/routes/base.js
@@ -33,7 +33,6 @@ router.get('/', function (req, res, next) {
     req.context.articles = data;
     req.template = HbsViews.index.get.hbs;
     next();
-    // res.send(HbsViews.index.get.hbs(req.context));
   }).catch(err => {
     return next(err);
   });
@@ -41,7 +40,6 @@ router.get('/', function (req, res, next) {
 
 router.get('/user', ensureLoggedIn, function (req, res, next) {
   res.set('Cache-Control', 'no-cache, no-store, must-revalidate');
-  // res.send(HbsViews.user.get.hbs(req.context));
   req.template = HbsViews.user.get.hbs;
   next();
 });

--- a/src/views/partials/articleBrief.hbs
+++ b/src/views/partials/articleBrief.hbs
@@ -19,7 +19,7 @@
  *  along with snekw.com.  If not, see <http://www.gnu.org/licenses/>.
  */
 }}
-<div class="container">
+<div class="container {{#if_eq public 2}}link-only{{/if_eq}}">
   <br/>
   <img src="{{indexImageUrl}}" width="550" height="250"/><br/>
   <div class="articleContainer indexarticleClickArea">


### PR DESCRIPTION
## Description of feature

Display link only articles to admins on the archive page.

## Description of implementation

Modified the query for building the archive page to allow for admins to see the link only articles.
Made the backgrounds for the link only articles darker.

## Remarks

Reference(s): #41 