### PR TITLE
Fix #63

### DIFF
--- a/src/srv/hbsSystem.js
+++ b/src/srv/hbsSystem.js
@@ -102,6 +102,14 @@ hbs.registerHelper('if_neq', function (a, b, opts) {
   }
 });
 
+hbs.registerHelper('if_less', function (a, b, opts) {
+  if (a < b) {
+    return opts.fn(this);
+  } else {
+    return opts.inverse(this);
+  }
+});
+
 hbs.registerHelper('timeFromNow', function (time) {
   return moment(time).fromNow();
 });

--- a/src/views/article/article.hbs
+++ b/src/views/article/article.hbs
@@ -34,9 +34,9 @@
     <div>
       <p>Written by: {{article.author.username}}</p>
       <p>Published: {{formatTime article.postedAt 'DD.MM.YYYY HH:mm'}}</p>
-      {{#if_neq article.postedAt article.updatedAt}}
+      {{#if_less article.postedAt article.updatedAt}}
         <p>Edited: {{formatTime article.updatedAt 'DD.MM.YYYY HH:mm - '}} {{timeFromNow article.updatedAt}}</p>
-      {{/if_neq}}
+      {{/if_less}}
     </div>
     {{>editControls article}}
   </div>


### PR DESCRIPTION
If this is a bug fix fill in below. Remove this line and the feature request template.
## Expected behavior
Edited at time should be hidden if the time is same as publication time.
## Actual behavior
Sometimes when the page is loaded the edited at time is visible.
## Description of fix
Changed the hbs helper used to determine if the edited at time should show.
Reference(s): #63 
