### PR TITLE
Add sitemap route

### DIFF
--- a/src/db/querys.js
+++ b/src/db/querys.js
@@ -36,11 +36,14 @@ const getLatestArticles = models.article.find({public: 1})
   .limit(10)
   .lean();
 
+const getArticleIds = models.article.find({}).select('_id').lean();
+
 const getArticleCount = models.article.count({public: 1});
 
 module.exports = {
   indexArticlesQuery,
   aboutGetQuery,
   getLatestArticles,
+  getArticleIds,
   getArticleCount
 };

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "snekw.com",
-  "version": "0.3.1",
+  "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1977,6 +1977,15 @@
         "is-arrayish": "^0.3.1"
       }
     },
+    "sitemap": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-1.13.0.tgz",
+      "integrity": "sha1-Vpy+IYAgKSamKiZs094Jyc60P4M=",
+      "requires": {
+        "underscore": "^1.7.0",
+        "url-join": "^1.1.0"
+      }
+    },
     "sliced": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
@@ -2205,10 +2214,20 @@
       "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
       "integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I="
     },
+    "underscore": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
+      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
+    },
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+    },
+    "url-join": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-1.1.0.tgz",
+      "integrity": "sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg="
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/src/package.json
+++ b/src/package.json
@@ -42,6 +42,7 @@
     "serve-favicon": "^2.5.0",
     "sharp": "^0.20.5",
     "shortid": "^2.2.12",
+    "sitemap": "^1.13.0",
     "validator": "^10.4.0"
   }
 }


### PR DESCRIPTION
## Description of feature
Generate sitemap for use by search engines.
## Description of implementation
Added an /sitemap.xml route that serves dynamically generated sitemap.
## Remarks
/about and /archive are static entries in the sitemap. All articles are dynamic.
Reference(s): #74 