### PR TITLE
Fix deprecations. Fix #76

### DIFF
--- a/src/db/controller.js
+++ b/src/db/controller.js
@@ -27,7 +27,7 @@ mongoose.Promise = global.Promise;
 
 function connect () {
   return new Promise((resolve, reject) => {
-    mongoose.connect(config.db.mongo.connectionString).then(() => {
+    mongoose.connect(config.db.mongo.connectionString, {useNewUrlParser: true}).then(() => {
       console.log('Connected to database: ' + mongoose.connection.db.s.databaseName);
       debug('Connected to database');
       cachedData.setupCache();

--- a/src/db/querys.js
+++ b/src/db/querys.js
@@ -38,7 +38,7 @@ const getLatestArticles = models.article.find({public: 1})
 
 const getArticleIds = models.article.find({}).select('_id').lean();
 
-const getArticleCount = models.article.count({public: 1});
+const getArticleCount = models.article.estimatedDocumentCount({public: 1});
 
 module.exports = {
   indexArticlesQuery,


### PR DESCRIPTION
## Expected behavior
No deprecation warnings.
## Actual behavior
Server outputs two deprecation warnings on startup.
## Description of fix
Specified the use of the new parser.
Use estimatedDocumentCount instead of count.

Reference(s): #75
